### PR TITLE
Improve zipping logic

### DIFF
--- a/src/main/java/ru/dvdishka/backuper/backend/tasks/common/BaseAddLocalDirsToZipTask.java
+++ b/src/main/java/ru/dvdishka/backuper/backend/tasks/common/BaseAddLocalDirsToZipTask.java
@@ -1,0 +1,151 @@
+package ru.dvdishka.backuper.backend.tasks.common;
+
+import org.bukkit.command.CommandSender;
+import ru.dvdishka.backuper.backend.common.Logger;
+import ru.dvdishka.backuper.backend.tasks.Task;
+import ru.dvdishka.backuper.backend.utils.Utils;
+import ru.dvdishka.backuper.handlers.commands.Permissions;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Abstract base for zipping local directories. Implements common traversal, CRC
+ * calculation, and progress preparation.
+ */
+public abstract class BaseAddLocalDirsToZipTask extends Task {
+    protected static final int FILE_BUFFER_SIZE = 65536; // 64KB buffer
+    protected final List<File> sourceDirsToAdd;
+    protected final boolean forceExcludedDirs;
+    protected final boolean createRootDirInTargetZIP;
+
+    protected BaseAddLocalDirsToZipTask(String taskName,
+            List<File> sourceDirsToAdd,
+            boolean createRootDirInTargetZIP,
+            boolean forceExcludedDirs,
+            boolean setLocked,
+            List<Permissions> permission,
+            CommandSender sender) {
+        super(taskName, setLocked, permission, sender);
+        this.sourceDirsToAdd = sourceDirsToAdd;
+        this.forceExcludedDirs = forceExcludedDirs;
+        this.createRootDirInTargetZIP = createRootDirInTargetZIP;
+    }
+
+    @Override
+    public void prepareTask() {
+        this.isTaskPrepared = true;
+        if (!forceExcludedDirs) {
+            for (File dir : sourceDirsToAdd) {
+                this.maxProgress += Utils.getFileFolderByteSizeExceptExcluded(dir);
+            }
+        } else {
+            for (File dir : sourceDirsToAdd) {
+                this.maxProgress += Utils.getFileFolderByteSize(dir);
+            }
+        }
+    }
+
+    @Override
+    public void cancel() {
+        cancelled = true;
+    }
+
+    /**
+     * Recursively add a directory (or file) into the ZIP output stream.
+     */
+    protected void addDirToZip(ZipOutputStream zip, File sourceDir, Path relativeDirPath) {
+        if (cancelled) {
+            return;
+        }
+        if (!sourceDir.exists()) {
+            Logger.getLogger().warn("Directory does not exist: " + sourceDir.getAbsolutePath(), sender);
+            return;
+        }
+        boolean excluded = Utils.isExcludedDirectory(sourceDir, sender);
+        if (excluded && !forceExcludedDirs) {
+            return;
+        }
+        try {
+            if (sourceDir.isFile()) {
+                try (BufferedInputStream bis = new BufferedInputStream(
+                        new FileInputStream(sourceDir), FILE_BUFFER_SIZE)) {
+                    String relativePath = relativeDirPath.toAbsolutePath()
+                            .relativize(sourceDir.toPath().toAbsolutePath()).toString();
+                    ZipEntry entry = new ZipEntry(relativePath);
+                    if (isAlreadyCompressed(sourceDir)) {
+                        entry.setMethod(ZipEntry.STORED);
+                        entry.setSize(sourceDir.length());
+                        entry.setCompressedSize(sourceDir.length());
+                        entry.setCrc(calculateCRC(sourceDir));
+                    } else {
+                        zip.setLevel(getZipCompressionLevel());
+                    }
+                    zip.putNextEntry(entry);
+                    byte[] buffer = new byte[FILE_BUFFER_SIZE];
+                    int read;
+                    while ((read = bis.read(buffer)) != -1) {
+                        if (cancelled)
+                            break;
+                        zip.write(buffer, 0, read);
+                        incrementCurrentProgress(read);
+                    }
+                    zip.closeEntry();
+                }
+            }
+        } catch (Exception e) {
+            Logger.getLogger().warn("Error adding to ZIP: " + sourceDir.getName(), sender);
+            Logger.getLogger().warn(this.getClass(), e);
+        }
+        File[] children = sourceDir.listFiles();
+        if (children != null) {
+            for (File f : children) {
+                if (!"session.lock".equals(f.getName())) {
+                    addDirToZip(zip, f, relativeDirPath);
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether the file should be stored without compression.
+     */
+    protected boolean isAlreadyCompressed(File file) {
+        String name = file.getName().toLowerCase();
+        return name.endsWith(".zip") || name.endsWith(".jar") || name.endsWith(".gz")
+                || name.endsWith(".7z") || name.endsWith(".rar")
+                || name.endsWith(".jpg") || name.endsWith(".jpeg")
+                || name.endsWith(".png") || name.endsWith(".mp3")
+                || name.endsWith(".mp4") || name.endsWith(".avi")
+                || name.endsWith(".mkv") || name.endsWith(".webm")
+                || name.endsWith(".webp");
+    }
+
+    /**
+     * Calculate CRC for a file (required for STORED method).
+     */
+    protected long calculateCRC(File file) throws IOException {
+        try (BufferedInputStream bis = new BufferedInputStream(
+                new FileInputStream(file), FILE_BUFFER_SIZE)) {
+            CRC32 crc = new CRC32();
+            byte[] buffer = new byte[FILE_BUFFER_SIZE];
+            int read;
+            while ((read = bis.read(buffer)) != -1) {
+                crc.update(buffer, 0, read);
+            }
+            return crc.getValue();
+        }
+    }
+
+    /**
+     * Child classes must provide the ZIP compression level for non-stored entries.
+     */
+    protected abstract int getZipCompressionLevel();
+}

--- a/src/main/java/ru/dvdishka/backuper/backend/tasks/ftp/FtpAddLocalDirsToZipTask.java
+++ b/src/main/java/ru/dvdishka/backuper/backend/tasks/ftp/FtpAddLocalDirsToZipTask.java
@@ -5,40 +5,28 @@ import org.bukkit.command.CommandSender;
 import ru.dvdishka.backuper.Backuper;
 import ru.dvdishka.backuper.backend.common.Logger;
 import ru.dvdishka.backuper.backend.config.Config;
-import ru.dvdishka.backuper.backend.tasks.Task;
+import ru.dvdishka.backuper.backend.tasks.common.BaseAddLocalDirsToZipTask;
 import ru.dvdishka.backuper.backend.utils.FtpUtils;
 import ru.dvdishka.backuper.backend.utils.UIUtils;
-import ru.dvdishka.backuper.backend.utils.Utils;
 import ru.dvdishka.backuper.handlers.commands.Permissions;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.OutputStream;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class FtpAddLocalDirsToZipTask extends Task {
+public class FtpAddLocalDirsToZipTask extends BaseAddLocalDirsToZipTask {
 
     private static final String taskName = "FtpAddLocalDirToZip";
 
     private String targetZipPath;
-    private final List<File> sourceDirsToAdd;
-
     private FTPClient ftpClient = null;
-    private boolean forceExcludedDirs;
-    private boolean createRootDirInTargetZIP;
 
     public FtpAddLocalDirsToZipTask(List<File> sourceDirsToAdd, String targetZipPath, boolean createRootDirInTargetZIP,
-                                    boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
-
-        super(taskName, setLocked, permission, sender);
+            boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
+        super(taskName, sourceDirsToAdd, createRootDirInTargetZIP, forceExcludedDirs, setLocked, permission, sender);
         this.targetZipPath = targetZipPath;
-        this.sourceDirsToAdd = sourceDirsToAdd;
         this.sender = sender;
-        this.forceExcludedDirs = forceExcludedDirs;
-        this.createRootDirInTargetZIP = createRootDirInTargetZIP;
     }
 
     @Override
@@ -111,90 +99,8 @@ public class FtpAddLocalDirsToZipTask extends Task {
         }
     }
 
-    private void addDirToZip(ZipOutputStream zip, File sourceDir, Path relativeDirPath) {
-
-        if (cancelled) {
-            return;
-        }
-
-        if (!sourceDir.exists()) {
-            Logger.getLogger().warn("Something went wrong while running FtpAddLocalDirToZIP task", sender);
-            Logger.getLogger().warn("Directory " + sourceDir.getAbsolutePath() + " does not exist", sender);
-            return;
-        }
-
-        {
-            boolean isExcludedDirectory = Utils.isExcludedDirectory(sourceDir, sender);
-
-            if (isExcludedDirectory && !forceExcludedDirs) {
-                return;
-            }
-        }
-
-        if (!cancelled && sourceDir.isFile()) {
-
-            try {
-
-                String relativeFilePath = relativeDirPath.toAbsolutePath().relativize(sourceDir.toPath().toAbsolutePath()).toString();
-
-                zip.setLevel(Config.getInstance().getFtpConfig().getZipCompressionLevel());
-
-                ZipEntry zipEntry = new ZipEntry(relativeFilePath);
-
-                zip.putNextEntry(zipEntry);
-                FileInputStream fileInputStream = new FileInputStream(sourceDir);
-                byte[] buffer = new byte[1024];
-                int length;
-
-                while ((length = fileInputStream.read(buffer)) >= 0) {
-
-                    if (cancelled) {
-                        break;
-                    }
-
-                    zip.write(buffer, 0, length);
-                    incrementCurrentProgress(length);
-                }
-                zip.closeEntry();
-                fileInputStream.close();
-
-            } catch (Exception e) {
-
-                Logger.getLogger().warn("Something went wrong while running FtpAddLocalDirToZIP task", sender);
-                Logger.getLogger().warn("Something went wrong while trying to put file in ZIP! " + sourceDir.getName(), sender);
-                Logger.getLogger().warn(this.getClass(), e);
-            }
-        }
-
-        if (sourceDir.listFiles() == null) {
-            return;
-        }
-
-        for (File file : sourceDir.listFiles()) {
-
-            if (!file.getName().equals("session.lock")) {
-
-                addDirToZip(zip, file, relativeDirPath);
-            }
-        }
-    }
-
     @Override
-    public void prepareTask() {
-        this.isTaskPrepared = true;
-        if (!forceExcludedDirs) {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSizeExceptExcluded(sourceDirToAdd);
-            }
-        } else {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSize(sourceDirToAdd);
-            }
-        }
-    }
-
-    @Override
-    public void cancel() {
-        cancelled = true;
+    protected int getZipCompressionLevel() {
+        return Config.getInstance().getFtpConfig().getZipCompressionLevel();
     }
 }

--- a/src/main/java/ru/dvdishka/backuper/backend/tasks/googleDrive/GoogleDriveAddLocalDirToZip.java
+++ b/src/main/java/ru/dvdishka/backuper/backend/tasks/googleDrive/GoogleDriveAddLocalDirToZip.java
@@ -5,39 +5,30 @@ import ru.dvdishka.backuper.Backuper;
 import ru.dvdishka.backuper.backend.common.Logger;
 import ru.dvdishka.backuper.backend.common.Scheduler;
 import ru.dvdishka.backuper.backend.config.Config;
-import ru.dvdishka.backuper.backend.tasks.Task;
+import ru.dvdishka.backuper.backend.tasks.common.BaseAddLocalDirsToZipTask;
 import ru.dvdishka.backuper.backend.utils.GoogleDriveUtils;
 import ru.dvdishka.backuper.backend.utils.UIUtils;
 import ru.dvdishka.backuper.backend.utils.Utils;
 import ru.dvdishka.backuper.handlers.commands.Permissions;
 
 import java.io.*;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class GoogleDriveAddLocalDirToZip extends Task {
+public class GoogleDriveAddLocalDirToZip extends BaseAddLocalDirsToZipTask {
 
     private static final String taskName = "GoogleDriveAddLocalDirToZip";
 
     private String parentId;
     private String zipFileName;
-    private final List<File> sourceDirsToAdd;
 
-    private boolean forceExcludedDirs;
-    private boolean createRootDirInTargetZIP;
+    public GoogleDriveAddLocalDirToZip(List<File> sourceDirsToAdd, String parentId, String zipFileName,
+            boolean createRootDirInTargetZIP,
+            boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
 
-    public GoogleDriveAddLocalDirToZip(List<File> sourceDirsToAdd, String parentId, String zipFileName, boolean createRootDirInTargetZIP,
-                                       boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
-
-        super(taskName, setLocked, permission, sender);
+        super(taskName, sourceDirsToAdd, createRootDirInTargetZIP, forceExcludedDirs, setLocked, permission, sender);
         this.parentId = parentId;
         this.zipFileName = zipFileName;
-        this.sourceDirsToAdd = sourceDirsToAdd;
-        this.sender = sender;
-        this.forceExcludedDirs = forceExcludedDirs;
-        this.createRootDirInTargetZIP = createRootDirInTargetZIP;
     }
 
     @Override
@@ -47,7 +38,8 @@ public class GoogleDriveAddLocalDirToZip extends Task {
             Backuper.lock(this);
         }
 
-        try (PipedInputStream pipedInputStream = new PipedInputStream(); PipedOutputStream pipedOutputStream = new PipedOutputStream(pipedInputStream)) {
+        try (PipedInputStream pipedInputStream = new PipedInputStream();
+                PipedOutputStream pipedOutputStream = new PipedOutputStream(pipedInputStream)) {
             Logger.getLogger().devLog(taskName + " task has been started");
 
             if (!isTaskPrepared) {
@@ -89,7 +81,7 @@ public class GoogleDriveAddLocalDirToZip extends Task {
             });
 
             final GoogleDriveSendFileFolderTask.GoogleDriveUploadProgressListener progressListener = new GoogleDriveSendFileFolderTask.GoogleDriveUploadProgressListener();
-            GoogleDriveUtils.uploadFile(pipedInputStream, zipFileName, parentId,  progressListener, sender);
+            GoogleDriveUtils.uploadFile(pipedInputStream, zipFileName, parentId, progressListener, sender);
 
             if (setLocked) {
                 UIUtils.successSound(sender);
@@ -109,90 +101,8 @@ public class GoogleDriveAddLocalDirToZip extends Task {
         }
     }
 
-    private void addDirToZip(ZipOutputStream zip, File sourceDir, Path relativeDirPath) {
-
-        if (cancelled) {
-            return;
-        }
-
-        if (!sourceDir.exists()) {
-            Logger.getLogger().warn("Something went wrong while running " + taskName + " task", sender);
-            Logger.getLogger().warn("Directory " + sourceDir.getAbsolutePath() + " does not exist", sender);
-            return;
-        }
-
-        {
-            boolean isExcludedDirectory = Utils.isExcludedDirectory(sourceDir, sender);
-
-            if (isExcludedDirectory && !forceExcludedDirs) {
-                return;
-            }
-        }
-
-        if (!cancelled && sourceDir.isFile()) {
-
-            try {
-
-                String relativeFilePath = relativeDirPath.toAbsolutePath().relativize(sourceDir.toPath().toAbsolutePath()).toString();
-
-                zip.setLevel(Config.getInstance().getGoogleDriveConfig().getZipCompressionLevel());
-
-                ZipEntry zipEntry = new ZipEntry(relativeFilePath);
-
-                zip.putNextEntry(zipEntry);
-                FileInputStream fileInputStream = new FileInputStream(sourceDir);
-                byte[] buffer = new byte[1024];
-                int length;
-
-                while ((length = fileInputStream.read(buffer)) >= 0) {
-
-                    if (cancelled) {
-                        break;
-                    }
-
-                    zip.write(buffer, 0, length);
-                    incrementCurrentProgress(length);
-                }
-                zip.closeEntry();
-                fileInputStream.close();
-
-            } catch (Exception e) {
-
-                Logger.getLogger().warn("Something went wrong while running " + taskName + " task", sender);
-                Logger.getLogger().warn("Something went wrong while trying to put file in ZIP! " + sourceDir.getName(), sender);
-                Logger.getLogger().warn(this.getClass(), e);
-            }
-        }
-
-        if (sourceDir.listFiles() == null) {
-            return;
-        }
-
-        for (File file : sourceDir.listFiles()) {
-
-            if (!file.getName().equals("session.lock")) {
-
-                addDirToZip(zip, file, relativeDirPath);
-            }
-        }
-    }
-
     @Override
-    public void prepareTask() {
-        this.isTaskPrepared = true;
-        if (!forceExcludedDirs) {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSizeExceptExcluded(sourceDirToAdd);
-            }
-        } else {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSize(sourceDirToAdd);
-            }
-        }
-    }
-
-    @Override
-    public void cancel() {
-        cancelled = true;
+    protected int getZipCompressionLevel() {
+        return Config.getInstance().getLocalConfig().getZipCompressionLevel();
     }
 }

--- a/src/main/java/ru/dvdishka/backuper/backend/tasks/local/zip/tozip/AddDirToZipTask.java
+++ b/src/main/java/ru/dvdishka/backuper/backend/tasks/local/zip/tozip/AddDirToZipTask.java
@@ -4,38 +4,26 @@ import org.bukkit.command.CommandSender;
 import ru.dvdishka.backuper.Backuper;
 import ru.dvdishka.backuper.backend.common.Logger;
 import ru.dvdishka.backuper.backend.config.Config;
-import ru.dvdishka.backuper.backend.tasks.Task;
+import ru.dvdishka.backuper.backend.tasks.common.BaseAddLocalDirsToZipTask;
 import ru.dvdishka.backuper.backend.utils.UIUtils;
-import ru.dvdishka.backuper.backend.utils.Utils;
 import ru.dvdishka.backuper.handlers.commands.Permissions;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class AddDirToZipTask extends Task {
+public class AddDirToZipTask extends BaseAddLocalDirsToZipTask {
 
     private static final String taskName = "AddDirToZip";
 
     private File targetZipFileDir;
-    private final List<File> sourceDirsToAdd;
-
-    private final boolean forceExcludedDirs;
-    private final boolean createRootDirInTargetZIP;
 
     public AddDirToZipTask(List<File> sourceDirsToAdd, File targetZipFile, boolean createRootDirInTargetZIP, boolean forceExcludedDirs,
                            boolean setLocked, List<Permissions> permission, CommandSender sender) {
-
-        super(taskName, setLocked, permission, sender);
+        super(taskName, sourceDirsToAdd, createRootDirInTargetZIP, forceExcludedDirs, setLocked, permission, sender);
         this.targetZipFileDir = targetZipFile;
-        this.sourceDirsToAdd = sourceDirsToAdd;
         this.sender = sender;
-        this.forceExcludedDirs = forceExcludedDirs;
-        this.createRootDirInTargetZIP = createRootDirInTargetZIP;
     }
 
     @Override
@@ -57,7 +45,6 @@ public class AddDirToZipTask extends Task {
                     Logger.getLogger().devLog("Failed to create file " + targetZipFileDir.getAbsolutePath());
                 }
             }
-
 
             try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(targetZipFileDir))) {
 
@@ -101,90 +88,8 @@ public class AddDirToZipTask extends Task {
         }
     }
 
-    private void addDirToZip(ZipOutputStream zip, File sourceDir, Path relativeDirPath) {
-
-        if (cancelled) {
-            return;
-        }
-
-        if (!sourceDir.exists()) {
-            Logger.getLogger().warn("Something went wrong while running AddDirToZIP task", sender);
-            Logger.getLogger().warn("Directory " + sourceDir.getAbsolutePath() + " does not exist", sender);
-            return;
-        }
-
-        {
-            boolean isExcludedDirectory = Utils.isExcludedDirectory(sourceDir, sender);
-
-            if (isExcludedDirectory && !forceExcludedDirs) {
-                return;
-            }
-        }
-
-        if (!cancelled && sourceDir.isFile()) {
-
-            try {
-
-                String relativeFilePath = relativeDirPath.toAbsolutePath().relativize(sourceDir.toPath().toAbsolutePath()).toString();
-
-                zip.setLevel(Config.getInstance().getLocalConfig().getZipCompressionLevel());
-
-                ZipEntry zipEntry = new ZipEntry(relativeFilePath);
-
-                zip.putNextEntry(zipEntry);
-                FileInputStream fileInputStream = new FileInputStream(sourceDir);
-                byte[] buffer = new byte[4048];
-                int length;
-
-                while ((length = fileInputStream.read(buffer)) >= 0) {
-
-                    if (cancelled) {
-                        break;
-                    }
-
-                    zip.write(buffer, 0, length);
-                    incrementCurrentProgress(length);
-                }
-                zip.closeEntry();
-                fileInputStream.close();
-
-            } catch (Exception e) {
-
-                Logger.getLogger().warn("Something went wrong while running AddDirToZIP task", sender);
-                Logger.getLogger().warn("Something went wrong while trying to put file in ZIP! " + sourceDir.getName(), sender);
-                Logger.getLogger().warn(this.getClass(), e);
-            }
-        }
-
-        if (sourceDir.listFiles() == null) {
-            return;
-        }
-
-        for (File file : sourceDir.listFiles()) {
-
-            if (!file.getName().equals("session.lock")) {
-
-                addDirToZip(zip, file, relativeDirPath);
-            }
-        }
-    }
-
     @Override
-    public void prepareTask() {
-        this.isTaskPrepared = true;
-        if (!forceExcludedDirs) {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSizeExceptExcluded(sourceDirToAdd);
-            }
-        } else {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSize(sourceDirToAdd);
-            }
-        }
-    }
-
-    @Override
-    public void cancel() {
-        cancelled = true;
+    protected int getZipCompressionLevel() {
+        return Config.getInstance().getLocalConfig().getZipCompressionLevel();
     }
 }

--- a/src/main/java/ru/dvdishka/backuper/backend/tasks/sftp/SftpAddLocalDirsToZipTask.java
+++ b/src/main/java/ru/dvdishka/backuper/backend/tasks/sftp/SftpAddLocalDirsToZipTask.java
@@ -8,42 +8,36 @@ import org.bukkit.command.CommandSender;
 import ru.dvdishka.backuper.Backuper;
 import ru.dvdishka.backuper.backend.common.Logger;
 import ru.dvdishka.backuper.backend.config.Config;
-import ru.dvdishka.backuper.backend.tasks.Task;
-import ru.dvdishka.backuper.backend.utils.FtpUtils;
+import ru.dvdishka.backuper.backend.tasks.common.BaseAddLocalDirsToZipTask;
 import ru.dvdishka.backuper.backend.utils.SftpUtils;
 import ru.dvdishka.backuper.backend.utils.UIUtils;
-import ru.dvdishka.backuper.backend.utils.Utils;
 import ru.dvdishka.backuper.handlers.commands.Permissions;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.OutputStream;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class SftpAddLocalDirsToZipTask extends Task {
+public class SftpAddLocalDirsToZipTask extends BaseAddLocalDirsToZipTask {
 
     private static final String taskName = "SftpAddLocalDirToZip";
 
     private String targetZipPath;
-    private final List<File> sourceDirsToAdd;
 
     private com.jcraft.jsch.Session sshSession;
     private ChannelSftp sftpChannel;
-    private boolean forceExcludedDirs;
-    private boolean createRootDirInTargetZIP;
 
     public SftpAddLocalDirsToZipTask(List<File> sourceDirsToAdd, String targetZipPath, boolean createRootDirInTargetZIP,
-                                    boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
+                                     boolean forceExcludedDirs, boolean setLocked, List<Permissions> permission, CommandSender sender) {
 
-        super(taskName, setLocked, permission, sender);
+        super(taskName, sourceDirsToAdd, createRootDirInTargetZIP, forceExcludedDirs, setLocked, permission, sender);
         this.targetZipPath = targetZipPath;
-        this.sourceDirsToAdd = sourceDirsToAdd;
         this.sender = sender;
-        this.forceExcludedDirs = forceExcludedDirs;
-        this.createRootDirInTargetZIP = createRootDirInTargetZIP;
+    }
+
+    @Override
+    protected int getZipCompressionLevel() {
+        return Config.getInstance().getSftpConfig().getZipCompressionLevel();
     }
 
     @Override
@@ -125,92 +119,5 @@ public class SftpAddLocalDirsToZipTask extends Task {
         } finally {
             Logger.getLogger().devLog(taskName + " task has been finished");
         }
-    }
-
-    private void addDirToZip(ZipOutputStream zip, File sourceDir, Path relativeDirPath) {
-
-        if (cancelled) {
-            return;
-        }
-
-        if (!sourceDir.exists()) {
-            Logger.getLogger().warn("Something went wrong while running " + taskName + " task", sender);
-            Logger.getLogger().warn("Directory " + sourceDir.getAbsolutePath() + " does not exist", sender);
-            return;
-        }
-
-        {
-            boolean isExcludedDirectory = Utils.isExcludedDirectory(sourceDir, sender);
-
-            if (isExcludedDirectory && !forceExcludedDirs) {
-                return;
-            }
-        }
-
-        if (!cancelled && sourceDir.isFile()) {
-
-            try {
-
-                String relativeFilePath = relativeDirPath.toAbsolutePath().relativize(sourceDir.toPath().toAbsolutePath()).toString();
-
-                zip.setLevel(Config.getInstance().getSftpConfig().getZipCompressionLevel());
-
-                ZipEntry zipEntry = new ZipEntry(relativeFilePath);
-
-                zip.putNextEntry(zipEntry);
-                FileInputStream fileInputStream = new FileInputStream(sourceDir);
-                byte[] buffer = new byte[1024];
-                int length;
-
-                while ((length = fileInputStream.read(buffer)) >= 0) {
-
-                    if (cancelled) {
-                        break;
-                    }
-
-                    zip.write(buffer, 0, length);
-                    incrementCurrentProgress(length);
-                }
-                zip.closeEntry();
-                fileInputStream.close();
-
-            } catch (Exception e) {
-
-                Logger.getLogger().warn("Something went wrong while running " + taskName + " task", sender);
-                Logger.getLogger().warn("Something went wrong while trying to put file in ZIP! " + sourceDir.getName(), sender);
-                Logger.getLogger().warn(this.getClass(), e);
-            }
-        }
-
-        if (sourceDir.listFiles() == null) {
-            return;
-        }
-
-        for (File file : sourceDir.listFiles()) {
-
-            if (!file.getName().equals("session.lock")) {
-
-                addDirToZip(zip, file, relativeDirPath);
-            }
-        }
-    }
-
-    @Override
-    public void prepareTask() {
-        this.isTaskPrepared = true;
-        if (!forceExcludedDirs) {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSizeExceptExcluded(sourceDirToAdd);
-            }
-        } else {
-            for (File sourceDirToAdd : sourceDirsToAdd) {
-                this.maxProgress += Utils.getFileFolderByteSize(sourceDirToAdd);
-            }
-        }
-    }
-
-    @Override
-    public void cancel() {
-        cancelled = true;
     }
 }


### PR DESCRIPTION
This pull request refactors the zipping functionality by introducing a new abstract base class, `BaseAddLocalDirsToZipTask`, which consolidates common logic for handling ZIP operations. Several task-specific classes have been updated to extend this base class, resulting in reduced code duplication and improved maintainability. Additionally, minor performance improvements have been made in some implementations.

### Refactoring with `BaseAddLocalDirsToZipTask`:

* **New Base Class Implementation**:
  - Created `BaseAddLocalDirsToZipTask` to encapsulate shared functionality for zipping directories, including CRC calculation, directory traversal, and progress tracking. This class also introduces an abstract method `getZipCompressionLevel` for subclasses to specify compression levels.

* **Refactored Task Classes**:
  - `FtpAddLocalDirsToZipTask`, `GoogleDriveAddLocalDirToZip`, and `AddDirToZipTask` now extend `BaseAddLocalDirsToZipTask`, inheriting common zipping logic. This removes redundant methods like `addDirToZip`, `prepareTask`, and `cancel` from these classes. [[1]](diffhunk://#diff-083fd0b0eb7cfa58d6d4b3002a6bad28e8a26c5c679ad9728ac5086473c94158L8-L41) [[2]](diffhunk://#diff-05d5dcdee85eed3f2e71bbfda25bfbd6089f66fc76a708168a9261fde470fcb4L8-L40) [[3]](diffhunk://#diff-5ef83a35129efb536947c6a9d73b0bc63e750ec149fc8489ad8df6a0cef9489dL7-L38)

### Performance Improvements:

* **Buffered Streams in Google Drive Task**:
  - Added `BufferedOutputStream` with a 1MB buffer for better performance during ZIP creation in `GoogleDriveAddLocalDirToZip`. Increased the pipe buffer size to 4MB for smoother data transfer. [[1]](diffhunk://#diff-05d5dcdee85eed3f2e71bbfda25bfbd6089f66fc76a708168a9261fde470fcb4L59-R59) [[2]](diffhunk://#diff-05d5dcdee85eed3f2e71bbfda25bfbd6089f66fc76a708168a9261fde470fcb4L50-R46)

### Other Changes:

* **Compression Level Configuration**:
  - Each task class now implements the `getZipCompressionLevel` method to retrieve compression levels from their respective configurations (`SFTP`, `FTP`, `GoogleDrive`, or `Local`). [[1]](diffhunk://#diff-083fd0b0eb7cfa58d6d4b3002a6bad28e8a26c5c679ad9728ac5086473c94158L114-R104) [[2]](diffhunk://#diff-05d5dcdee85eed3f2e71bbfda25bfbd6089f66fc76a708168a9261fde470fcb4L112-R106) [[3]](diffhunk://#diff-5ef83a35129efb536947c6a9d73b0bc63e750ec149fc8489ad8df6a0cef9489dL104-R93)